### PR TITLE
fix android compilation error

### DIFF
--- a/android/src/main/kotlin/com/weplenish/flutter_wifi_connect/FlutterWifiConnectPlugin.kt
+++ b/android/src/main/kotlin/com/weplenish/flutter_wifi_connect/FlutterWifiConnectPlugin.kt
@@ -224,7 +224,7 @@ class FlutterWifiConnectPlugin() : FlutterPlugin, MethodCallHandler {
   fun getNearbySsid(@NonNull ssidPrefix: String): String?{
     val results = wifiManager.scanResults
     return results.filter { scanResult -> scanResult.SSID.startsWith(ssidPrefix) }
-            .maxBy { scanResult -> scanResult.level }?.SSID
+            .maxByOrNull { scanResult -> scanResult.level }?.SSID
   }
 
   @Suppress("DEPRECATION")


### PR DESCRIPTION
Fixes Android compilation issue when target and compile API versions are set to 33

```
flutter_wifi_connect/FlutterWifiConnectPlugin.kt: (227, 14): Using 'maxBy((T) -> R): T?' is an error. Use maxByOrNull instead.```